### PR TITLE
Add schema generator basics

### DIFF
--- a/src/main/java/io/ballerina/asyncapi/AsyncApiToBalGenerator.java
+++ b/src/main/java/io/ballerina/asyncapi/AsyncApiToBalGenerator.java
@@ -22,7 +22,7 @@ import io.ballerina.asyncapi.codegenerator.application.CodeGenerator;
 
 public class AsyncApiToBalGenerator {
     public static void main(String[] args) {
-        var codeGenerator = new CodeGenerator("file_path");
+        var codeGenerator = new CodeGenerator(System.getenv().get("SPEC_FILE_PATH"));
         codeGenerator.generate();
     }
 }

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/application/CodeGenerator.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/application/CodeGenerator.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.asyncapi.codegenerator.application;
 
+import io.ballerina.asyncapi.codegenerator.configuration.Constants;
 import io.ballerina.asyncapi.codegenerator.controller.Controller;
 import io.ballerina.asyncapi.codegenerator.controller.SchemaController;
 import io.ballerina.asyncapi.codegenerator.repository.FileRepository;
@@ -34,8 +35,9 @@ public class CodeGenerator implements Application {
     public void generate() {
         FileRepository fileRepository = new FileRepositoryImpl();
         String asyncApiSpec = fileRepository.getFileContent(specPath);
+        String balTemplate = fileRepository.getFileContentFromResources(Constants.HTTP_BAL_TEMPLATE_FILE_NAME);
 
         Controller schemaController = new SchemaController();
-        schemaController.generateBalCode(asyncApiSpec);
+        schemaController.generateBalCode(asyncApiSpec, balTemplate);
     }
 }

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/configuration/Constants.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/configuration/Constants.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.asyncapi.codegenerator.configuration;
+
+import java.util.List;
+
+public final class Constants {
+    public static final String HTTP_BAL_TEMPLATE_FILE_NAME = "types.bal";
+    public static final List<String> BAL_KEYWORDS;
+    public static final List<String> BAL_TYPES;
+    public static final String ESCAPE_PATTERN = "([\\[\\]\\\\?!<>@#&~`*\\-=^+();:\\/\\_{}\\s|.$])";
+    //TODO Update keywords if Ballerina Grammer changes
+    private static final String[] KEYWORDS = new String[]{"abort", "aborted", "abstract", "all", "annotation",
+            "any", "anydata", "boolean", "break", "byte", "catch", "channel", "check", "checkpanic", "client",
+            "committed", "const", "continue", "decimal", "else", "error", "external", "fail", "final", "finally",
+            "float", "flush", "fork", "function", "future", "handle", "if", "import", "in", "int", "is", "join",
+            "json", "listener", "lock", "match", "new", "object", "OBJECT_INIT", "onretry", "parameter", "panic",
+            "private", "public", "record", "remote", "resource", "retries", "retry", "return", "returns", "service",
+            "source", "start", "stream", "string", "table", "transaction", "try", "type", "typedesc", "typeof",
+            "trap", "throw", "wait", "while", "with", "worker", "var", "version", "xml", "xmlns", "BOOLEAN_LITERAL",
+            "NULL_LITERAL", "ascending", "descending", "foreach", "map", "group", "from", "default", "field",
+            "limit", "as", "on", "isolated", "readonly", "distinct", "where", "select", "do", "transactional"
+            , "commit", "enum", "base16", "base64", "rollback", "configurable", "class", "module", "never",
+            "outer", "order", "null", "key", "let", "by", "equals"};
+    private static final String[] TYPES = new String[]{"int", "any", "anydata", "boolean", "byte", "float", "int",
+            "json", "string", "table", "var", "xml"};
+
+    static {
+        BAL_KEYWORDS = List.of(KEYWORDS);
+        BAL_TYPES = List.of(TYPES);
+    }
+
+    private Constants() {
+    }
+}

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/controller/Controller.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/controller/Controller.java
@@ -19,5 +19,5 @@
 package io.ballerina.asyncapi.codegenerator.controller;
 
 public interface Controller {
-    void generateBalCode(String spec);
+    void generateBalCode(String spec, String balTemplate);
 }

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/controller/SchemaController.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/controller/SchemaController.java
@@ -18,14 +18,50 @@
 
 package io.ballerina.asyncapi.codegenerator.controller;
 
+import io.apicurio.datamodels.Library;
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
+import io.apicurio.datamodels.asyncapi.v2.models.Aai20Document;
+import io.ballerina.asyncapi.codegenerator.usecase.GenerateRecordNode;
+import io.ballerina.asyncapi.codegenerator.usecase.UseCase;
+import io.ballerina.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.tools.text.TextDocuments;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.ballerinalang.formatter.core.Formatter;
+import org.ballerinalang.formatter.core.FormatterException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class SchemaController implements Controller {
     private static final Logger logger = LogManager.getLogger(SchemaController.class);
 
     @Override
-    public void generateBalCode(String spec) {
-        logger.error(spec);
+    public void generateBalCode(String spec, String balTemplate) {
+        AaiDocument asyncApiSpec = (Aai20Document) Library.readDocumentFromJSONString(spec);
+
+        List<ModuleMemberDeclarationNode> recordNodes = new ArrayList<>();
+        for (Map.Entry<String, AaiSchema> fields : asyncApiSpec.components.schemas.entrySet()) {
+            UseCase generateRecordNode = new GenerateRecordNode(asyncApiSpec, fields);
+            recordNodes.add(generateRecordNode.execute());
+        }
+
+        var textDocument = TextDocuments.from(balTemplate);
+        var syntaxTree = SyntaxTree.from(textDocument);
+        ModulePartNode oldRoot = syntaxTree.rootNode();
+        ModulePartNode newRoot = oldRoot.modify().withMembers(oldRoot.members().addAll(recordNodes)).apply();
+        var modifiedTree = syntaxTree.replaceNode(oldRoot, newRoot);
+
+        try {
+            var formattedSourceCode = Formatter.format(modifiedTree).toSourceCode();
+            logger.debug("Generated the source code for the schemas: {}", formattedSourceCode);
+        } catch (FormatterException e) {
+            logger.error("Could not format the generated code, may be syntax issue in the generated code. " +
+                    "Generated code: {}", modifiedTree.toSourceCode());
+        }
     }
 }

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/repository/FileRepository.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/repository/FileRepository.java
@@ -20,4 +20,6 @@ package io.ballerina.asyncapi.codegenerator.repository;
 
 public interface FileRepository {
     String getFileContent(String filePath);
+
+    String getFileContentFromResources(String fileName);
 }

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/repository/FileRepositoryImpl.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/repository/FileRepositoryImpl.java
@@ -41,4 +41,27 @@ public class FileRepositoryImpl implements FileRepository {
             return null;
         }
     }
+
+    @Override
+    public String getFileContentFromResources(String fileName) {
+        try (var inputStream = getFileFromResourceAsStream(fileName)) {
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            logger.error("File not found: ".concat(fileName), e);
+            return null;
+        }
+    }
+
+    public InputStream getFileFromResourceAsStream(String fileName) {
+        // The class loader that loaded the class
+        var classLoader = getClass().getClassLoader();
+        var inputStream = classLoader.getResourceAsStream(fileName);
+
+        // the stream holding the file content
+        if (inputStream == null) {
+            throw new IllegalArgumentException("file not found! " + fileName);
+        } else {
+            return inputStream;
+        }
+    }
 }

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/GenerateRecordNode.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/GenerateRecordNode.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.asyncapi.codegenerator.usecase;
+
+import io.apicurio.datamodels.asyncapi.models.AaiDocument;
+import io.apicurio.datamodels.asyncapi.models.AaiSchema;
+import io.ballerina.asyncapi.codegenerator.usecase.utils.CodegenUtils;
+import io.ballerina.asyncapi.codegenerator.usecase.utils.DocCommentsUtils;
+import io.ballerina.compiler.syntax.tree.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.*;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.*;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.OPEN_BRACE_TOKEN;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.SEMICOLON_TOKEN;
+
+public class GenerateRecordNode implements UseCase {
+    private final AaiDocument asyncApiSpec;
+    private final Map.Entry<String, AaiSchema> recordFields;
+
+    private final CodegenUtils codegenUtils = new CodegenUtils();
+    private final DocCommentsUtils commentsUtils = new DocCommentsUtils();
+
+    public GenerateRecordNode(AaiDocument asyncApiSpec, Map.Entry<String, AaiSchema> recordFields) {
+        this.asyncApiSpec = asyncApiSpec;
+        this.recordFields = recordFields;
+    }
+
+    @Override
+    public TypeDefinitionNode execute() {
+        IdentifierToken typeName = AbstractNodeFactory
+                .createIdentifierToken(codegenUtils.escapeIdentifier(recordFields.getKey().trim()));
+        Token typeKeyWord = AbstractNodeFactory.createIdentifierToken("public type");
+        TypeDefinitionNode typeDefinitionNode;
+        List<Node> schemaDoc = new ArrayList<>();
+        List<Node> recordFieldList = new ArrayList<>();
+        for (Map.Entry<String, AaiSchema> field : recordFields.getValue().properties.entrySet()) {
+            addRecordField(field.getValue().required, recordFieldList, field, asyncApiSpec);
+        }
+        NodeList<Node> fieldNodes = createNodeList(recordFieldList);
+        var recordTypeDescriptorNode =
+                NodeFactory.createRecordTypeDescriptorNode(createToken(SyntaxKind.RECORD_KEYWORD),
+                        createToken(OPEN_BRACE_TOKEN), fieldNodes, null,
+                        createToken(SyntaxKind.CLOSE_BRACE_TOKEN));
+        var documentationNode =
+                createMarkdownDocumentationNode(createNodeList(schemaDoc));
+        var metadataNode = createMetadataNode(documentationNode, createEmptyNodeList());
+        typeDefinitionNode = NodeFactory.createTypeDefinitionNode(metadataNode,
+                null, typeKeyWord, typeName, recordTypeDescriptorNode, createToken(SEMICOLON_TOKEN));
+        return typeDefinitionNode;
+    }
+
+    /**
+     * This method generates a record field with given schema properties.
+     */
+    private void addRecordField(List<String> required, List<Node> recordFieldList, Map.Entry<String, AaiSchema> field,
+                                AaiDocument asyncApiSpec) {
+        // TODO: Handle allOf , oneOf, anyOf
+        RecordFieldNode recordFieldNode;
+        // API doc
+        List<Node> schemaDoc = new ArrayList<>();
+        String fieldN = codegenUtils.escapeIdentifier(field.getKey().trim());
+        if (field.getValue().description != null) {
+            schemaDoc.addAll(commentsUtils.createAPIDescriptionDoc(
+                    field.getValue().description, false));
+        } else if (field.getValue().$ref != null) {
+            String[] split = field.getValue().$ref.trim().split("/");
+            String componentName = codegenUtils.getValidName(split[split.length - 1], true);
+            if (asyncApiSpec.components.schemas.get(componentName) != null) {
+                AaiSchema schema = asyncApiSpec.components.schemas.get(componentName);
+                if (schema.description != null) {
+                    schemaDoc.addAll(commentsUtils.createAPIDescriptionDoc(
+                            schema.description, false));
+                }
+            }
+        }
+
+        //FiledName
+        var fieldName = AbstractNodeFactory.createIdentifierToken(fieldN);
+        // TODO: handle other types of identifiers too
+        Token typeName = AbstractNodeFactory.createIdentifierToken("string");
+        TypeDescriptorNode fieldTypeName = createBuiltinSimpleNameReferenceNode(null, typeName);
+        Token semicolonToken = AbstractNodeFactory.createIdentifierToken(";");
+        Token questionMarkToken = AbstractNodeFactory.createIdentifierToken("?");
+        var documentationNode = createMarkdownDocumentationNode(createNodeList(schemaDoc));
+        var metadataNode = createMetadataNode(documentationNode, createEmptyNodeList());
+        if (required != null) {
+            if (!required.contains(field.getKey().trim())) {
+                recordFieldNode = NodeFactory.createRecordFieldNode(metadataNode, null,
+                        fieldTypeName, fieldName, questionMarkToken, semicolonToken);
+            } else {
+                recordFieldNode = NodeFactory.createRecordFieldNode(metadataNode, null,
+                        fieldTypeName, fieldName, null, semicolonToken);
+            }
+        } else {
+            recordFieldNode = NodeFactory.createRecordFieldNode(metadataNode, null,
+                    fieldTypeName, fieldName, questionMarkToken, semicolonToken);
+        }
+        recordFieldList.add(recordFieldNode);
+    }
+}

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/utils/CodegenUtils.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/utils/CodegenUtils.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.asyncapi.codegenerator.usecase.utils;
+
+import io.ballerina.asyncapi.codegenerator.configuration.Constants;
+
+import java.util.Locale;
+import java.util.Optional;
+
+public class CodegenUtils {
+    /**
+     * This method will escape special characters used in method names and identifiers.
+     *
+     * @param identifier - identifier or method name
+     * @return - escaped string
+     */
+    public String escapeIdentifier(String identifier) {
+        if (!identifier.matches("\\b[_a-zA-Z][_a-zA-Z0-9]*\\b") || Constants.BAL_KEYWORDS.stream()
+                .anyMatch(identifier::equals)) {
+
+            // TODO: Remove this `if`. Refer - https://github.com/ballerina-platform/ballerina-lang/issues/23045
+            if (identifier.equals("error")) {
+                identifier = "_error";
+            } else {
+                identifier = identifier.replaceAll(Constants.ESCAPE_PATTERN, "\\\\$1");
+                if (identifier.endsWith("?")) {
+                    if (identifier.charAt(identifier.length() - 2) == '\\') {
+                        var stringBuilder = new StringBuilder(identifier);
+                        stringBuilder.deleteCharAt(identifier.length() - 2);
+                        identifier = stringBuilder.toString();
+                    }
+                    if (Constants.BAL_KEYWORDS.stream().anyMatch(Optional.of(identifier)
+                            .filter(sStr -> sStr.length() != 0)
+                            .map(sStr -> sStr.substring(0, sStr.length() - 1))
+                            .orElse(identifier)::equals)) {
+                        identifier = "'" + identifier;
+                    } else {
+                        return identifier;
+                    }
+                } else {
+                    identifier = "'" + identifier;
+                }
+            }
+        }
+        return identifier;
+    }
+
+    /**
+     * Generate operationId by removing special characters.
+     *
+     * @param identifier input function name, record name or operation Id
+     * @return string with new generated name
+     */
+    public String getValidName(String identifier, boolean isSchema) {
+        //For the flatten enable we need to remove first Part of valid name check
+        // this - > !identifier.matches("\\b[a-zA-Z][a-zA-Z0-9]*\\b") &&
+        if (!identifier.matches("\\b[0-9]*\\b")) {
+            String[] split = identifier.split(Constants.ESCAPE_PATTERN);
+            var validName = new StringBuilder();
+            for (String part : split) {
+                if (!part.isBlank()) {
+                    if (split.length > 1) {
+                        part = part.substring(0, 1).toUpperCase(Locale.ENGLISH) +
+                                part.substring(1).toLowerCase(Locale.ENGLISH);
+                    }
+                    validName.append(part);
+                }
+            }
+            identifier = validName.toString();
+        }
+        if (isSchema) {
+            return identifier.substring(0, 1).toUpperCase(Locale.ENGLISH) + identifier.substring(1);
+        } else {
+            return identifier.substring(0, 1).toLowerCase(Locale.ENGLISH) + identifier.substring(1);
+        }
+    }
+}

--- a/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/utils/DocCommentsUtils.java
+++ b/src/main/java/io/ballerina/asyncapi/codegenerator/usecase/utils/DocCommentsUtils.java
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.asyncapi.codegenerator.usecase.utils;
+
+import io.ballerina.compiler.syntax.tree.*;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.ballerina.compiler.syntax.tree.AbstractNodeFactory.*;
+import static io.ballerina.compiler.syntax.tree.NodeFactory.*;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.*;
+
+/**
+ * This class util for maintain the API doc comment related functions.
+ */
+public class DocCommentsUtils {
+    /**
+     * Extract extension for find the display annotation.
+     *
+     * @param extensions - openapi extension.
+     * @return Annotation node list.
+     */
+    public NodeList<AnnotationNode> extractDisplayAnnotation(Map<String, Object> extensions) {
+        NodeList<AnnotationNode> annotationNodes = createEmptyNodeList();
+        if (extensions != null) {
+            for (Map.Entry<String, Object> extension : extensions.entrySet()) {
+                if (extension.getKey().trim().equals("x-display")) {
+                    AnnotationNode annotationNode = getAnnotationNode(extension);
+                    annotationNodes = createNodeList(annotationNode);
+                }
+            }
+        }
+        return annotationNodes;
+    }
+
+    private AnnotationNode getAnnotationNode(Map.Entry<String, Object> extension) {
+
+        LinkedHashMap<String, String> extFields = (LinkedHashMap<String, String>) extension.getValue();
+        List<Node> annotFields = new ArrayList<>();
+        if (!extFields.isEmpty()) {
+            for (Map.Entry<String, String> field : extFields.entrySet()) {
+
+                BasicLiteralNode valueExpr = createBasicLiteralNode(STRING_LITERAL,
+                        createLiteralValueToken(SyntaxKind.STRING_LITERAL_TOKEN,
+                                '"' + field.getValue().trim() + '"',
+                                createEmptyMinutiaeList(),
+                                createEmptyMinutiaeList()));
+                SpecificFieldNode fields = createSpecificFieldNode(null,
+                        createIdentifierToken(field.getKey().trim()),
+                        createToken(COLON_TOKEN), valueExpr);
+                annotFields.add(fields);
+                annotFields.add(createToken(COMMA_TOKEN));
+            }
+            if (annotFields.size() == 2) {
+                annotFields.remove(1);
+            }
+        }
+
+        MappingConstructorExpressionNode annotValue = createMappingConstructorExpressionNode(
+                createToken(OPEN_BRACE_TOKEN), createSeparatedNodeList(annotFields),
+                createToken(CLOSE_BRACE_TOKEN));
+
+        SimpleNameReferenceNode annotateReference =
+                createSimpleNameReferenceNode(createIdentifierToken("display"));
+
+        return createAnnotationNode(createToken(SyntaxKind.AT_TOKEN)
+                , annotateReference, annotValue);
+    }
+
+
+    /**
+     * Generate metaDataNode with display annotation.
+     */
+    public MetadataNode getMetadataNodeForDisplayAnnotation(Map.Entry<String, Object> extension) {
+
+        MetadataNode metadataNode;
+        AnnotationNode annotationNode = getAnnotationNode(extension);
+        metadataNode = createMetadataNode(null, createNodeList(annotationNode));
+        return metadataNode;
+    }
+
+    public List<MarkdownDocumentationLineNode> createAPIDescriptionDoc(
+            String description, boolean addExtraLine) {
+        String[] descriptionLines = description.split("\n");
+        List<MarkdownDocumentationLineNode> documentElements = new ArrayList<>();
+        for (String line : descriptionLines) {
+            MarkdownDocumentationLineNode documentationLineNode =
+                    createMarkdownDocumentationLineNode(DOCUMENTATION_DESCRIPTION,
+                            createToken(SyntaxKind.HASH_TOKEN), createNodeList(createIdentifierToken(line)));
+            documentElements.add(documentationLineNode);
+        }
+        if (addExtraLine) {
+            MarkdownDocumentationLineNode newLine = createMarkdownDocumentationLineNode(null,
+                    createToken(SyntaxKind.HASH_TOKEN), createEmptyNodeList());
+            documentElements.add(newLine);
+        }
+        return documentElements;
+    }
+
+    public MarkdownParameterDocumentationLineNode createAPIParamDoc(String paramName, String description) {
+        String[] paramDescriptionLines = description.split("\n");
+        List<Node> documentElements = new ArrayList<>();
+        for (String line : paramDescriptionLines) {
+            if (!line.isBlank()) {
+                documentElements.add(createIdentifierToken(line + " "));
+            }
+        }
+        return createMarkdownParameterDocumentationLineNode(null, createToken(SyntaxKind.HASH_TOKEN),
+                createToken(SyntaxKind.PLUS_TOKEN), createIdentifierToken(paramName),
+                createToken(SyntaxKind.MINUS_TOKEN), createNodeList(documentElements));
+    }
+}
+

--- a/src/main/resources/types.bal
+++ b/src/main/resources/types.bal
@@ -1,0 +1,7 @@
+@display {label: "Connection Config"}
+public type ListenerConfiguration record {
+    @display {label: "Listener Port"}
+    int port;
+    @display {label: "Verification Token"}
+    string verificationToken;
+};


### PR DESCRIPTION
Add the basic implementation of the schema generation. Ballerina records will be generated from the async api spec. For now, only the string types will be generated